### PR TITLE
Add sticky navbar with scroll spy

### DIFF
--- a/luis-site/src/components/Navbar.tsx
+++ b/luis-site/src/components/Navbar.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+
+const sections = ["about", "education", "experience", "projects", "timeline", "contact"];
+
+export default function Navbar() {
+  const [active, setActive] = useState<string>("about");
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActive(entry.target.id);
+          }
+        });
+      },
+      { threshold: 0.6 }
+    );
+
+    sections.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+
+    return () => {
+      sections.forEach((id) => {
+        const el = document.getElementById(id);
+        if (el) observer.unobserve(el);
+      });
+    };
+  }, []);
+
+  return (
+    <nav className="sticky top-0 z-50 bg-background">
+      <ul className="flex space-x-4 p-4">
+        {sections.map((id) => (
+          <li key={id}>
+            <a href={`#${id}`} className={active === id ? "font-bold" : ""}>
+              {id.charAt(0).toUpperCase() + id.slice(1)}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/luis-site/src/pages/index.tsx
+++ b/luis-site/src/pages/index.tsx
@@ -1,3 +1,15 @@
+import Navbar from "@/components/Navbar";
+
 export default function Home() {
-  return <div className="min-h-screen bg-background text-text"></div>;
+  return (
+    <div className="min-h-screen bg-background text-text">
+      <Navbar />
+      <section id="about" className="min-h-screen p-8">About</section>
+      <section id="education" className="min-h-screen p-8">Education</section>
+      <section id="experience" className="min-h-screen p-8">Experience</section>
+      <section id="projects" className="min-h-screen p-8">Projects</section>
+      <section id="timeline" className="min-h-screen p-8">Timeline</section>
+      <section id="contact" className="min-h-screen p-8">Contact</section>
+    </div>
+  );
 }

--- a/luis-site/src/styles/globals.css
+++ b/luis-site/src/styles/globals.css
@@ -1,3 +1,6 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+html {
+  scroll-behavior: smooth;
+}


### PR DESCRIPTION
## Summary
- add sticky navbar with smooth scrolling links
- mark active section using IntersectionObserver
- create section ids on home page for navigation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a24f7d41e88322acf93a3b7b2ddff4