### PR TITLE
Add leadership section with scroll animations

### DIFF
--- a/luis-site/src/components/Navbar.tsx
+++ b/luis-site/src/components/Navbar.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useState } from "react";
 
-const sections = ["about", "education", "experience", "projects", "timeline", "contact"];
+const sections = [
+  "about",
+  "education",
+  "experience",
+  "leadership",
+  "projects",
+  "timeline",
+  "contact",
+];
 
 export default function Navbar() {
   const [active, setActive] = useState<string>("about");

--- a/luis-site/src/pages/index.tsx
+++ b/luis-site/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import Navbar from "@/components/Navbar";
 import ResumeSummary from "@/sections/ResumeSummary";
+import Leadership from "@/sections/Leadership";
 
 export default function Home() {
   return (
@@ -10,6 +11,7 @@ export default function Home() {
       <section id="about" className="min-h-screen p-8">About</section>
       <section id="education" className="min-h-screen p-8">Education</section>
       <section id="experience" className="min-h-screen p-8">Experience</section>
+      <Leadership />
       <section id="projects" className="min-h-screen p-8">Projects</section>
       <section id="timeline" className="min-h-screen p-8">Timeline</section>
       <section id="contact" className="min-h-screen p-8">Contact</section>

--- a/luis-site/src/sections/Experience.tsx
+++ b/luis-site/src/sections/Experience.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, ReactElement } from "react";
 
 function BriefcaseIcon({ className = "" }: { className?: string }) {
   return (
@@ -100,7 +100,7 @@ interface ExperienceCardProps {
   role: string;
   period: string;
   details: string[];
-  icon: JSX.Element;
+  icon: ReactElement;
 }
 
 function ExperienceCard({ company, role, period, details, icon }: ExperienceCardProps) {

--- a/luis-site/src/sections/Leadership.tsx
+++ b/luis-site/src/sections/Leadership.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+
+interface LeadershipRole {
+  role: string;
+  organization: string;
+  period: string;
+  link?: string;
+}
+
+function LeadershipItem({ role, organization, period, link }: LeadershipRole) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.1 });
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className={`transition-opacity transition-transform duration-700 ease-out transform ${
+        visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
+      }`}
+    >
+      <div className="pl-4 border-l-2 border-primary">
+        <h3 className="text-xl font-semibold">{role}</h3>
+        <p className="text-sm text-gray-600">
+          {link ? (
+            <Link href={link} className="text-primary underline" target="_blank">
+              {organization}
+            </Link>
+          ) : (
+            organization
+          )}
+        </p>
+        <p className="text-xs text-gray-500">{period}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function Leadership() {
+  const roles: LeadershipRole[] = [
+    {
+      role: "President, Economics Club",
+      organization: "UNO Economics Club",
+      period: "Aug 2023 – May 2024",
+      link: "https://www.unomaha.edu/college-of-business-administration/economics/index.php",
+    },
+    {
+      role: "Vice President, Financial Management Association",
+      organization: "UNO FMA",
+      period: "Aug 2022 – May 2023",
+      link: "https://www.unomaha.edu/college-of-business-administration/finance-banking/fma.php",
+    },
+    {
+      role: "Student Representative, GIPS Board of Education",
+      organization: "Grand Island Public Schools",
+      period: "Aug 2018 – May 2019",
+      link: "https://meeting.assemblemeetings.com/Public/Agenda/63?meeting=39306",
+    },
+  ];
+
+  return (
+    <section id="leadership" className="min-h-screen p-8">
+      <h2 className="text-3xl font-bold text-center mb-8">Leadership</h2>
+      <div className="space-y-8 max-w-2xl mx-auto">
+        {roles.map((item) => (
+          <LeadershipItem key={item.role} {...item} />
+        ))}
+      </div>
+    </section>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add leadership section featuring major roles with scroll animations and external links
- wire leadership section into navigation and homepage
- adjust Experience card typing to use ReactElement

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a25d830fa083229166ee9ec85e4e0f