### PR TITLE
Add interactive timeline component

### DIFF
--- a/luis-site/data/timeline.json
+++ b/luis-site/data/timeline.json
@@ -1,0 +1,68 @@
+[
+  {
+    "date": "Aug 2018 – May 2019",
+    "title": "Student Representative, GIPS Board of Education",
+    "description": "Represented students on the Grand Island Public Schools Board of Education.",
+    "links": [
+      "https://meeting.assemblemeetings.com/Public/Agenda/63?meeting=39306"
+    ]
+  },
+  {
+    "date": "Aug 2019",
+    "title": "Began dual-degree program at UNO",
+    "description": "Started pursuing Economics and Mathematics degrees at the University of Nebraska at Omaha."
+  },
+  {
+    "date": "2021",
+    "title": "Undergraduate recognition and honor societies",
+    "description": "Joined recognition and honor societies; see awards index for details.",
+    "links": [
+      "https://www.unomaha.edu/special-events/student-honors-convocation/awards/index.php"
+    ]
+  },
+  {
+    "date": "Nov 2021 – Apr 2022",
+    "title": "Financial Representative Intern, Northwestern Mutual",
+    "description": "Served as a Financial Representative Intern at Northwestern Mutual."
+  },
+  {
+    "date": "Mar 2022",
+    "title": "Presented finite-field numerical ranges research at UNO SRCAF",
+    "description": "Presented research on finite-field numerical ranges at the UNO Student Research and Creative Activity Fair.",
+    "links": [
+      "https://digitalcommons.unomaha.edu/srcaf/2022/schedule/95/"
+    ]
+  },
+  {
+    "date": "Apr 2022 – Feb 2024",
+    "title": "Financial Planning Analyst, Ludacka Wealth Partners",
+    "description": "Worked as a Financial Planning Analyst for Ludacka Wealth Partners."
+  },
+  {
+    "date": "May 2023",
+    "title": "Graduated UNO with 4.0 GPAs; Married Madison",
+    "description": "Graduated with dual degrees and married high school sweetheart Madison."
+  },
+  {
+    "date": "Feb 2024 – Present",
+    "title": "Actuarial Analyst, Telos Actuarial",
+    "description": "Joined Telos Actuarial as an Actuarial Analyst.",
+    "links": [
+      "https://www.telosactuarial.com/about"
+    ]
+  },
+  {
+    "date": "July 2024",
+    "title": "Profile in GIPS Rise Newsletter; Harvest speaker announcement",
+    "description": "Featured in the GIPS Rise Newsletter and announced as a Harvest speaker.",
+    "links": [
+      "https://gipsfoundation.org/alumni/rise-newsletter/newsletters/2024/july-2024-copy-copy.html",
+      "https://my.onecause.com/event/organizations/sf-0013c00001zv03cAAA/events/vevt%3A58ff120c-6989-4bd7-95ab-d2430df558d0/home/story"
+    ]
+  },
+  {
+    "date": "May–June 2025",
+    "title": "Super Secret Special Project",
+    "description": "Details coming soon; stay tuned."
+  }
+]

--- a/luis-site/src/components/Timeline.tsx
+++ b/luis-site/src/components/Timeline.tsx
@@ -1,0 +1,88 @@
+import { useRef, useState } from "react";
+import events from "../../data/timeline.json";
+
+type TimelineEvent = {
+  date: string;
+  title: string;
+  description: string;
+  links?: string[];
+};
+
+export default function Timeline() {
+  const data = events as TimelineEvent[];
+  const [active, setActive] = useState(0);
+  const sectionRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const navRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const handleSelect = (index: number) => {
+    setActive(index);
+    sectionRefs.current[index]?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  const handleKey = (e: React.KeyboardEvent<HTMLButtonElement>, idx: number) => {
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      const next = (idx + 1) % data.length;
+      navRefs.current[next]?.focus();
+      handleSelect(next);
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      const prev = (idx - 1 + data.length) % data.length;
+      navRefs.current[prev]?.focus();
+      handleSelect(prev);
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex overflow-x-auto space-x-4 pb-4" role="tablist">
+        {data.map((ev, i) => (
+          <button
+            key={ev.title}
+            ref={(el) => (navRefs.current[i] = el)}
+            className={`px-3 py-2 rounded border focus:outline-none focus:ring-2 focus:ring-blue-500 ${i === active ? "bg-blue-600 text-white" : "bg-gray-200 text-black"}`}
+            role="tab"
+            tabIndex={0}
+            aria-selected={i === active}
+            onMouseEnter={() => setActive(i)}
+            onFocus={() => setActive(i)}
+            onClick={() => handleSelect(i)}
+            onKeyDown={(e) => handleKey(e, i)}
+            title={ev.title}
+          >
+            {ev.date}
+          </button>
+        ))}
+      </div>
+      <div>
+        {data.map((ev, i) => (
+          <div
+            key={ev.title}
+            ref={(el) => (sectionRefs.current[i] = el)}
+            hidden={active !== i}
+            role="tabpanel"
+            aria-labelledby={ev.title}
+            className="p-4"
+          >
+            <h3 className="text-xl font-semibold">{ev.title}</h3>
+            <p className="mb-2">{ev.description}</p>
+            {ev.links && (
+              <ul className="list-disc list-inside space-y-1">
+                {ev.links.map((link) => (
+                  <li key={link}>
+                    <a
+                      href={link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 underline"
+                    >
+                      {link}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/luis-site/src/pages/index.tsx
+++ b/luis-site/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import Navbar from "@/components/Navbar";
 import ResumeSummary from "@/sections/ResumeSummary";
 import Leadership from "@/sections/Leadership";
+import Timeline from "@/components/Timeline";
 
 export default function Home() {
   return (
@@ -13,7 +14,9 @@ export default function Home() {
       <section id="experience" className="min-h-screen p-8">Experience</section>
       <Leadership />
       <section id="projects" className="min-h-screen p-8">Projects</section>
-      <section id="timeline" className="min-h-screen p-8">Timeline</section>
+      <section id="timeline" className="min-h-screen p-8">
+        <Timeline />
+      </section>
       <section id="contact" className="min-h-screen p-8">Contact</section>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `Timeline` component that renders events with keyboard, click, and hover support
- source events from new `data/timeline.json`
- display timeline on the home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a25fed49c88322a9e92a7de713bbca