### PR TITLE
Refactor sections with reusable Card and Tooltip

### DIFF
--- a/luis-site/src/components/Card.tsx
+++ b/luis-site/src/components/Card.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import type { ReactNode } from "react";
+
+interface CardProps {
+  imageSrc?: string;
+  icon?: ReactNode;
+  title: string;
+  summary: ReactNode;
+  detail: ReactNode;
+}
+
+export default function Card({ imageSrc, icon, title, summary, detail }: CardProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="bg-white rounded shadow p-6">
+      <div className="flex items-center mb-2">
+        {imageSrc ? (
+          <img src={imageSrc} alt="" className="w-12 h-12 mr-4 object-cover" />
+        ) : icon ? (
+          <div className="w-12 h-12 mr-4 flex items-center justify-center">{icon}</div>
+        ) : null}
+        <h3 className="text-xl font-semibold">{title}</h3>
+      </div>
+      <div className="text-sm text-gray-600 mb-2">{summary}</div>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="text-primary underline text-sm"
+        aria-expanded={open}
+      >
+        {open ? "Hide details" : "View details"}
+      </button>
+      {open && <div className="mt-2 text-sm">{detail}</div>}
+    </div>
+  );
+}

--- a/luis-site/src/components/Timeline.tsx
+++ b/luis-site/src/components/Timeline.tsx
@@ -37,7 +37,9 @@ export default function Timeline() {
         {data.map((ev, i) => (
           <button
             key={ev.title}
-            ref={(el) => (navRefs.current[i] = el)}
+            ref={(el) => {
+              navRefs.current[i] = el;
+            }}
             className={`px-3 py-2 rounded border focus:outline-none focus:ring-2 focus:ring-blue-500 ${i === active ? "bg-blue-600 text-white" : "bg-gray-200 text-black"}`}
             role="tab"
             tabIndex={0}
@@ -56,7 +58,9 @@ export default function Timeline() {
         {data.map((ev, i) => (
           <div
             key={ev.title}
-            ref={(el) => (sectionRefs.current[i] = el)}
+            ref={(el) => {
+              sectionRefs.current[i] = el;
+            }}
             hidden={active !== i}
             role="tabpanel"
             aria-labelledby={ev.title}

--- a/luis-site/src/components/Tooltip.tsx
+++ b/luis-site/src/components/Tooltip.tsx
@@ -1,0 +1,54 @@
+import { useId, useState, cloneElement } from "react";
+import type { ReactElement, ReactNode, MouseEvent, FocusEvent } from "react";
+
+interface TooltipProps {
+  content: ReactNode;
+  children: ReactElement;
+}
+
+export default function Tooltip({ content, children }: TooltipProps) {
+  const [visible, setVisible] = useState(false);
+  const id = useId();
+  const childProps = children.props as {
+    onMouseEnter?: (e: MouseEvent<HTMLElement>) => void;
+    onMouseLeave?: (e: MouseEvent<HTMLElement>) => void;
+    onFocus?: (e: FocusEvent<HTMLElement>) => void;
+    onBlur?: (e: FocusEvent<HTMLElement>) => void;
+  };
+
+  const trigger = cloneElement(
+    children,
+    {
+      "aria-describedby": id,
+      onMouseEnter: (e: MouseEvent<HTMLElement>) => {
+        childProps.onMouseEnter?.(e);
+        setVisible(true);
+      },
+      onMouseLeave: (e: MouseEvent<HTMLElement>) => {
+        childProps.onMouseLeave?.(e);
+        setVisible(false);
+      },
+      onFocus: (e: FocusEvent<HTMLElement>) => {
+        childProps.onFocus?.(e);
+        setVisible(true);
+      },
+      onBlur: (e: FocusEvent<HTMLElement>) => {
+        childProps.onBlur?.(e);
+        setVisible(false);
+      },
+    } as unknown as React.HTMLAttributes<HTMLElement>
+  );
+
+  return (
+    <span className="relative inline-block">
+      {trigger}
+      <span
+        id={id}
+        role="tooltip"
+        className={`absolute left-1/2 -translate-x-1/2 mt-2 whitespace-nowrap bg-gray-800 text-white text-xs rounded px-2 py-1 transition-opacity ${visible ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+      >
+        {content}
+      </span>
+    </span>
+  );
+}

--- a/luis-site/src/sections/Awards.tsx
+++ b/luis-site/src/sections/Awards.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import Tooltip from "../components/Tooltip";
 
 interface AwardBadgeProps {
   title: string;
@@ -6,25 +6,15 @@ interface AwardBadgeProps {
 }
 
 function AwardBadge({ title, detail }: AwardBadgeProps) {
-  const [show, setShow] = useState(false);
-
   return (
-    <button
-      type="button"
-      aria-label={`${title}. ${detail}`}
-      onMouseEnter={() => setShow(true)}
-      onMouseLeave={() => setShow(false)}
-      onFocus={() => setShow(true)}
-      onBlur={() => setShow(false)}
-      className="relative m-2 px-4 py-2 bg-primary text-white rounded-full focus:outline-none focus:ring-2 focus:ring-primary"
-    >
-      {title}
-      <span
-        className={`absolute left-1/2 transform -translate-x-1/2 mt-2 whitespace-nowrap bg-gray-800 text-white text-xs rounded px-2 py-1 transition-opacity ${show ? "opacity-100" : "opacity-0"}`}
+    <Tooltip content={detail}>
+      <button
+        type="button"
+        className="m-2 px-4 py-2 bg-primary text-white rounded-full focus:outline-none focus:ring-2 focus:ring-primary"
       >
-        {detail}
-      </span>
-    </button>
+        {title}
+      </button>
+    </Tooltip>
   );
 }
 

--- a/luis-site/src/sections/Education.tsx
+++ b/luis-site/src/sections/Education.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import Card from "../components/Card";
 
 function AcademicCapIcon({ className = "" }: { className?: string }) {
   return (
@@ -14,7 +14,7 @@ function AcademicCapIcon({ className = "" }: { className?: string }) {
   );
 }
 
-interface EducationCardProps {
+interface Education {
   institution: string;
   degree: string;
   gpa: string;
@@ -23,85 +23,71 @@ interface EducationCardProps {
   honors: string[];
 }
 
-function EducationCard({
-  institution,
-  degree,
-  gpa,
-  concentration,
-  scholarships,
-  honors,
-}: EducationCardProps) {
-  const [showScholarships, setShowScholarships] = useState(false);
-  const [showHonors, setShowHonors] = useState(false);
-
-  return (
-    <div className="bg-white rounded shadow p-6 flex flex-col">
-      <div className="flex items-center mb-4">
-        <AcademicCapIcon className="h-6 w-6 text-primary mr-2" />
-        <h3 className="text-xl font-semibold">{institution}</h3>
-      </div>
-      <p className="font-medium mb-1">{degree}</p>
-      {concentration && <p className="mb-1">Concentration: {concentration}</p>}
-      <p className="mb-2">GPA: {gpa}</p>
-      <div className="mt-auto">
-        <button
-          onClick={() => setShowScholarships(!showScholarships)}
-          className="text-primary underline mb-2"
-        >
-          Scholarships
-        </button>
-        {showScholarships && (
-          <ul className="list-disc list-inside mb-4">
-            {scholarships.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
-        )}
-        <button
-          onClick={() => setShowHonors(!showHonors)}
-          className="text-primary underline"
-        >
-          Honor Societies
-        </button>
-        {showHonors && (
-          <ul className="list-disc list-inside mt-2">
-            {honors.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
-        )}
-      </div>
-    </div>
-  );
-}
+const schools: Education[] = [
+  {
+    institution: "University of Nebraska at Omaha",
+    degree: "B.S. Economics & Mathematics",
+    gpa: "4.0",
+    concentration: "Economics and Mathematics",
+    scholarships: [
+      "Regents Scholarship (full tuition)",
+      "Distinguished Scholars Program",
+    ],
+    honors: [
+      "Pi Mu Epsilon (Mathematics)",
+      "Omicron Delta Epsilon (Economics)",
+    ],
+  },
+  {
+    institution: "Grand Island Senior High",
+    degree: "High School Diploma",
+    gpa: "4.0",
+    concentration: "College Preparatory Curriculum",
+    scholarships: ["Local Academic Scholarships"],
+    honors: ["National Honor Society"],
+  },
+];
 
 export default function Education() {
   return (
     <section id="education" className="min-h-screen p-8">
       <h2 className="text-3xl font-bold text-center mb-8">Education</h2>
       <div className="grid gap-6 md:grid-cols-2">
-        <EducationCard
-          institution="University of Nebraska at Omaha"
-          degree="B.S. Economics & Mathematics"
-          gpa="4.0"
-          concentration="Economics and Mathematics"
-          scholarships={[
-            "Regents Scholarship (full tuition)",
-            "Distinguished Scholars Program",
-          ]}
-          honors={[
-            "Pi Mu Epsilon (Mathematics)",
-            "Omicron Delta Epsilon (Economics)",
-          ]}
-        />
-        <EducationCard
-          institution="Grand Island Senior High"
-          degree="High School Diploma"
-          gpa="4.0"
-          concentration="College Preparatory Curriculum"
-          scholarships={["Local Academic Scholarships"]}
-          honors={["National Honor Society"]}
-        />
+        {schools.map((s) => (
+          <Card
+            key={s.institution}
+            icon={<AcademicCapIcon className="h-6 w-6 text-primary" />}
+            title={s.institution}
+            summary={`${s.degree} — GPA: ${s.gpa}`}
+            detail={
+              <div>
+                {s.concentration && (
+                  <p className="mb-2">Concentration: {s.concentration}</p>
+                )}
+                {s.scholarships.length > 0 && (
+                  <>
+                    <p className="font-medium">Scholarships</p>
+                    <ul className="list-disc list-inside mb-2">
+                      {s.scholarships.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </>
+                )}
+                {s.honors.length > 0 && (
+                  <>
+                    <p className="font-medium">Honor Societies</p>
+                    <ul className="list-disc list-inside">
+                      {s.honors.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </>
+                )}
+              </div>
+            }
+          />
+        ))}
       </div>
     </section>
   );

--- a/luis-site/src/sections/Experience.tsx
+++ b/luis-site/src/sections/Experience.tsx
@@ -1,4 +1,5 @@
-import { useState, ReactElement } from "react";
+import type { ReactElement } from "react";
+import Card from "../components/Card";
 
 function BriefcaseIcon({ className = "" }: { className?: string }) {
   return (
@@ -95,7 +96,7 @@ function BuildingStorefrontIcon({ className = "" }: { className?: string }) {
   );
 }
 
-interface ExperienceCardProps {
+interface Experience {
   company: string;
   role: string;
   period: string;
@@ -103,84 +104,79 @@ interface ExperienceCardProps {
   icon: ReactElement;
 }
 
-function ExperienceCard({ company, role, period, details, icon }: ExperienceCardProps) {
-  const [expanded, setExpanded] = useState(false);
-
-  return (
-    <div
-      className="bg-white rounded shadow p-6 cursor-pointer transition-all duration-300 group"
-      onClick={() => setExpanded(!expanded)}
-    >
-      <div className="flex items-center mb-2">
-        {icon}
-        <h3 className="text-xl font-semibold ml-2">{role}</h3>
-      </div>
-      <p className="text-sm text-gray-600 mb-1">{company}</p>
-      <p className="text-xs text-gray-500 mb-2">{period}</p>
-      <ul className={`list-disc list-inside space-y-1 mt-2 transition-all duration-300 ${expanded ? "block" : "hidden group-hover:block"}`}>
-        {details.map((d) => (
-          <li key={d}>{d}</li>
-        ))}
-      </ul>
-    </div>
-  );
-}
+const experiences: Experience[] = [
+  {
+    company: "Telos Actuarial",
+    role: "Actuarial Analyst",
+    period: "May 2024 – Present",
+    icon: <CalculatorIcon className="h-6 w-6 text-primary" />,
+    details: [
+      "Build actuarial valuation models in R and Python",
+      "Streamline rate filing analyses for health insurers",
+    ],
+  },
+  {
+    company: "Ludacka Wealth Partners",
+    role: "Financial Planning Intern",
+    period: "May 2023 – Aug 2023",
+    icon: <BriefcaseIcon className="h-6 w-6 text-primary" />,
+    details: [
+      "Assisted advisors with portfolio analysis and client reports",
+      "Developed Excel tools to automate financial plan updates",
+    ],
+  },
+  {
+    company: "Northwestern Mutual",
+    role: "College Financial Representative",
+    period: "Jun 2022 – May 2023",
+    icon: <ChartBarIcon className="h-6 w-6 text-primary" />,
+    details: [
+      "Created personalized financial plans using proprietary tools",
+      "Coordinated marketing outreach generating new client leads",
+    ],
+  },
+  {
+    company: "UNO Math & Economics Department",
+    role: "Tutor",
+    period: "Aug 2021 – May 2023",
+    icon: <BookOpenIcon className="h-6 w-6 text-primary" />,
+    details: [
+      "Provided one-on-one tutoring for calculus and statistics",
+      "Led exam review sessions improving student outcomes",
+    ],
+  },
+  {
+    company: "Runza",
+    role: "Shift Supervisor",
+    period: "May 2018 – Aug 2021",
+    icon: <BuildingStorefrontIcon className="h-6 w-6 text-primary" />,
+    details: [
+      "Led team to deliver fast, friendly service during peak hours",
+      "Managed cash handling and closing procedures",
+    ],
+  },
+];
 
 export default function Experience() {
   return (
     <section id="experience" className="min-h-screen p-8">
       <h2 className="text-3xl font-bold text-center mb-8">Experience</h2>
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        <ExperienceCard
-          company="Telos Actuarial"
-          role="Actuarial Analyst"
-          period="May 2024 – Present"
-          icon={<CalculatorIcon className="h-6 w-6 text-primary" />}
-          details={[
-            "Build actuarial valuation models in R and Python",
-            "Streamline rate filing analyses for health insurers",
-          ]}
-        />
-        <ExperienceCard
-          company="Ludacka Wealth Partners"
-          role="Financial Planning Intern"
-          period="May 2023 – Aug 2023"
-          icon={<BriefcaseIcon className="h-6 w-6 text-primary" />}
-          details={[
-            "Assisted advisors with portfolio analysis and client reports",
-            "Developed Excel tools to automate financial plan updates",
-          ]}
-        />
-        <ExperienceCard
-          company="Northwestern Mutual"
-          role="College Financial Representative"
-          period="Jun 2022 – May 2023"
-          icon={<ChartBarIcon className="h-6 w-6 text-primary" />}
-          details={[
-            "Created personalized financial plans using proprietary tools",
-            "Coordinated marketing outreach generating new client leads",
-          ]}
-        />
-        <ExperienceCard
-          company="UNO Math & Economics Department"
-          role="Tutor"
-          period="Aug 2021 – May 2023"
-          icon={<BookOpenIcon className="h-6 w-6 text-primary" />}
-          details={[
-            "Provided one-on-one tutoring for calculus and statistics",
-            "Led exam review sessions improving student outcomes",
-          ]}
-        />
-        <ExperienceCard
-          company="Runza"
-          role="Shift Supervisor"
-          period="May 2018 – Aug 2021"
-          icon={<BuildingStorefrontIcon className="h-6 w-6 text-primary" />}
-          details={[
-            "Led team to deliver fast, friendly service during peak hours",
-            "Managed cash handling and closing procedures",
-          ]}
-        />
+        {experiences.map((exp) => (
+          <Card
+            key={exp.company + exp.role}
+            icon={exp.icon}
+            title={exp.role}
+            summary={`${exp.company} | ${exp.period}`}
+            detail={
+              <ul className="list-disc list-inside space-y-1">
+                {exp.details.map((d) => (
+                  <li key={d}>{d}</li>
+                ))}
+              </ul>
+            }
+          />
+        ))}
       </div>
     </section>
   );

--- a/luis-site/src/sections/Research.tsx
+++ b/luis-site/src/sections/Research.tsx
@@ -1,65 +1,49 @@
-import { useEffect, useRef, useState } from "react";
+import Card from "../components/Card";
 
-interface ProjectCardProps {
+interface Project {
   title: string;
   dates: string;
   summary: string;
   link: string;
 }
 
-function ProjectCard({ title, dates, summary, link }: ProjectCardProps) {
-  const ref = useRef<HTMLDivElement>(null);
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          setVisible(true);
-          observer.unobserve(entry.target);
-        }
-      });
-    }, { threshold: 0.1 });
-
-    if (ref.current) {
-      observer.observe(ref.current);
-    }
-
-    return () => observer.disconnect();
-  }, []);
-
-  return (
-    <div
-      ref={ref}
-      className={`bg-white rounded shadow p-6 transition-opacity transition-transform duration-700 ease-out transform ${visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}`}
-    >
-      <h3 className="text-xl font-semibold mb-2">{title}</h3>
-      <p className="text-sm text-gray-600 mb-2">{dates}</p>
-      <p className="mb-4">{summary}</p>
-      <a href={link} className="text-primary underline">
-        Learn more
-      </a>
-    </div>
-  );
-}
+const projects: Project[] = [
+  {
+    title: "Finite-Field Linear Algebra",
+    dates: "Jan 2022 – Mar 2022",
+    summary:
+      "Studied numerical ranges over finite fields and presented findings at the UNO Student Research and Creative Activity Fair.",
+    link: "https://digitalcommons.unomaha.edu/srcaf/2022/schedule/95/",
+  },
+  {
+    title: "Integer-Programming Wedding Venue Thesis",
+    dates: "Aug 2022 – May 2023",
+    summary:
+      "Honors thesis using integer programming to select an optimal wedding venue that minimizes guest travel distance.",
+    link: "https://digitalcommons.unomaha.edu/university_honors_program/197/",
+  },
+];
 
 export default function Research() {
   return (
     <section id="research" className="min-h-screen p-8">
       <h2 className="text-3xl font-bold text-center mb-8">Research</h2>
       <div className="grid gap-6 md:grid-cols-2">
-        <ProjectCard
-          title="Finite-Field Linear Algebra"
-          dates="Jan 2022 – Mar 2022"
-          summary="Studied numerical ranges over finite fields and presented findings at the UNO Student Research and Creative Activity Fair."
-          link="https://digitalcommons.unomaha.edu/srcaf/2022/schedule/95/"
-        />
-        <ProjectCard
-          title="Integer-Programming Wedding Venue Thesis"
-          dates="Aug 2022 – May 2023"
-          summary="Honors thesis using integer programming to select an optimal wedding venue that minimizes guest travel distance."
-          link="https://digitalcommons.unomaha.edu/university_honors_program/197/"
-        />
+        {projects.map((p) => (
+          <Card
+            key={p.title}
+            title={p.title}
+            summary={p.dates}
+            detail={
+              <>
+                <p className="mb-4">{p.summary}</p>
+                <a href={p.link} className="text-primary underline">
+                  Learn more
+                </a>
+              </>
+            }
+          />
+        ))}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add generic `Card` component with optional image/icon, title, summary, and toggleable details
- add accessible `Tooltip` component triggered on hover and focus using `aria-describedby`
- refactor Awards, Education, Experience, Research sections to use new components and clean up lists
- fix Timeline refs to satisfy TypeScript

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a263f40b70832293d4704bd19d3867