### PR TITLE
Add minimal LR logo and analytic background

### DIFF
--- a/luis-site/.gitignore
+++ b/luis-site/.gitignore
@@ -44,3 +44,4 @@ next-env.d.ts
 public/*.svg
 public/*.ico
 !public/headshot-placeholder.svg
+!public/logo.svg

--- a/luis-site/public/logo.svg
+++ b/luis-site/public/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="LR logo">
+  <text x="10" y="70" font-family="Arial, sans-serif" font-size="70" font-weight="bold" fill="#555">LR</text>
+</svg>

--- a/luis-site/src/styles/globals.css
+++ b/luis-site/src/styles/globals.css
@@ -1,6 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
 html {
   scroll-behavior: smooth;
+}
+
+body {
+  background-color: #f9fafb;
+  background-image:
+    linear-gradient(rgba(0, 0, 0, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 0, 0, 0.05) 1px, transparent 1px);
+  background-size: 40px 40px;
 }


### PR DESCRIPTION
## Summary
- add low-contrast LR monogram logo
- apply subtle grid background evoking data/analytics
- allow new logo to be committed

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a266091d388322b8606a2b0fe2eb09