### PR TITLE
chore: add accessibility linting and optimize images

### DIFF
--- a/luis-site/eslint.config.mjs
+++ b/luis-site/eslint.config.mjs
@@ -10,7 +10,11 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.extends(
+    "next/core-web-vitals",
+    "next/typescript",
+    "plugin:jsx-a11y/recommended"
+  ),
 ];
 
 export default eslintConfig;

--- a/luis-site/next.config.ts
+++ b/luis-site/next.config.ts
@@ -3,6 +3,10 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   reactStrictMode: true,
+  compress: true,
+  images: {
+    formats: ["image/avif", "image/webp"],
+  },
 };
 
 export default nextConfig;

--- a/luis-site/package-lock.json
+++ b/luis-site/package-lock.json
@@ -20,6 +20,7 @@
         "autoprefixer": "^10.4.21",
         "eslint": "^9",
         "eslint-config-next": "15.4.6",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
         "typescript": "^5"

--- a/luis-site/package.json
+++ b/luis-site/package.json
@@ -21,6 +21,7 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"

--- a/luis-site/src/components/Card.tsx
+++ b/luis-site/src/components/Card.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { ReactNode } from "react";
+import Image from "next/image";
 
 interface CardProps {
   imageSrc?: string;
@@ -16,7 +17,14 @@ export default function Card({ imageSrc, icon, title, summary, detail }: CardPro
     <div className="bg-white rounded shadow p-6">
       <div className="flex items-center mb-2">
         {imageSrc ? (
-          <img src={imageSrc} alt="" className="w-12 h-12 mr-4 object-cover" />
+          <Image
+            src={imageSrc}
+            alt=""
+            width={48}
+            height={48}
+            className="w-12 h-12 mr-4 object-cover"
+            loading="lazy"
+          />
         ) : icon ? (
           <div className="w-12 h-12 mr-4 flex items-center justify-center">{icon}</div>
         ) : null}

--- a/luis-site/src/sections/ResumeSummary.tsx
+++ b/luis-site/src/sections/ResumeSummary.tsx
@@ -1,14 +1,16 @@
 import React from "react";
+import Image from "next/image";
 
 export default function ResumeSummary() {
   return (
     <section id="resume-summary" className="min-h-screen p-8 flex flex-col items-center text-center">
-      <img
+      <Image
         src="/headshot-placeholder.svg"
         alt="Headshot of Luis Rodriguez"
         width={200}
         height={200}
         className="mb-4 rounded-full"
+        loading="lazy"
       />
       <p className="max-w-2xl mb-6">
         Luis Rodriguez is an Omaha-based Actuarial Analyst with a strong dual background in Economics and Mathematics, evidenced by his 4.0 GPA in both fields. He has a proven track record of applying analytical and programming skills to real-world financial and research problems. His experience spans actuarial science, financial planning, and academic research, complemented by leadership roles and professional certifications. A full résumé is available as a downloadable PDF for detailed viewing.


### PR DESCRIPTION
## Summary
- add `eslint-plugin-jsx-a11y` for accessibility linting
- swap `<img>` tags for Next.js `<Image>` with lazy loading
- enable compression and modern image formats in Next.js config

## Testing
- `npm run lint`
- `npm run build`
- `npx --yes lighthouse http://localhost:3000 --quiet --chrome-flags="--headless"` *(fails: The CHROME_PATH environment variable must be set to a Chrome/Chromium executable)*

------
https://chatgpt.com/codex/tasks/task_e_68a268928cac832294558e68c142579b