### PR TITLE
Add references data and render references list

### DIFF
--- a/luis-site/data/references.json
+++ b/luis-site/data/references.json
@@ -1,0 +1,22 @@
+[
+  {
+    "text": "GIPS Foundation Newsletter (July 2024) – Announcement of Luis and Madison Rodriguez as Harvest event speakers, noting their UNO graduation GPAs and new careers.",
+    "url": "https://gipsfoundation.org/alumni/rise-newsletter/newsletters/2024/july-2024-copy-copy.html"
+  },
+  {
+    "text": "Telos Actuarial – Company About Page – Listing Luis Rodriguez as an Actuarial Analyst on staff (Omaha, NE).",
+    "url": "https://www.telosactuarial.com/about"
+  },
+  {
+    "text": "UNO Digital Commons – Honors Thesis (May 2023) – “Optimizing Wedding Venue Selection Process Using Integer Programming” by Luis Rodriguez, University of Nebraska at Omaha.",
+    "url": "https://digitalcommons.unomaha.edu/university_honors_program/197/"
+  },
+  {
+    "text": "Luis Rodriguez – Curriculum Vitae (Dec 2024) – Personal CV detailing education, work experience, research, and awards.",
+    "url": "/LuisRodriguez_Resume.pdf"
+  },
+  {
+    "text": "Fitness Toolkit Web App – Luis’s GitHub Pages site for his Fitness Toolkit project, which inspired design elements of this personal site.",
+    "url": "https://luisitinrodriguez2001-cloud.github.io/Fitness-Toolkit/"
+  }
+]

--- a/luis-site/src/pages/index.tsx
+++ b/luis-site/src/pages/index.tsx
@@ -2,6 +2,7 @@ import Navbar from "@/components/Navbar";
 import ResumeSummary from "@/sections/ResumeSummary";
 import Leadership from "@/sections/Leadership";
 import Timeline from "@/components/Timeline";
+import references from "../../data/references.json";
 
 export default function Home() {
   return (
@@ -18,6 +19,18 @@ export default function Home() {
         <Timeline />
       </section>
       <section id="contact" className="min-h-screen p-8">Contact</section>
+      <section id="references" className="p-8">
+        <h2 className="text-xl font-bold mb-4">References</h2>
+        <ul className="list-disc pl-6 space-y-2">
+          {references.map((ref, index) => (
+            <li key={index}>
+              <a href={ref.url} target="_blank" rel="noopener noreferrer">
+                {ref.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- compile reference metadata from the design spec into `references.json`
- display a References section on the home page with secure external links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a26aee01e083228fd2236dc4a9cbc2