### PR TITLE
Build static site for Luis Rodriguez

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,581 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Luis Rodriguez – Personal Website</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Personal website for Luis Rodriguez, an Omaha-based actuarial analyst with experience spanning research, financial planning, and community leadership.">
+  <title>Luis Rodriguez · Actuarial Analyst</title>
   <link rel="stylesheet" href="styles.css">
+  <script defer src="script.js"></script>
 </head>
 <body>
-  <div id="app"></div>
-  <script type="module" src="main.js"></script>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+
+  <!-- Summary banner with primary contact details -->
+  <header class="site-header" role="banner">
+    <div class="summary-shell">
+      <div class="summary-text">
+        <p class="label">Personal site</p>
+        <h1>Luis Rodriguez</h1>
+        <p class="role">Actuarial Analyst</p>
+        <p class="location">Omaha, Nebraska</p>
+        <p class="contact">Email <a href="mailto:Luisitinrodriguez2001@gmail.com">Luisitinrodriguez2001@gmail.com</a></p>
+        <p class="intro">
+          Omaha-based actuarial analyst pairing dual degrees in Economics and Mathematics with hands-on research, financial planning, and community storytelling. This page captures the journey from a 2007 move from Cuba to present-day actuarial problem solving.
+        </p>
+      </div>
+      <nav aria-label="Section navigation" class="summary-nav">
+        <ul>
+          <li><a href="#storyline">Storyline</a></li>
+          <li><a href="#employment">Employment</a></li>
+          <li><a href="#education">Education</a></li>
+          <li><a href="#research">Research</a></li>
+          <li><a href="#presentations">Presentations</a></li>
+          <li><a href="#skills">Skills</a></li>
+          <li><a href="#leadership">Leadership</a></li>
+          <li><a href="#awards">Awards &amp; Honors</a></li>
+          <li><a href="#certifications">Certifications</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main-content" tabindex="-1">
+    <!-- Horizontal, swipeable timeline describing the narrative arc -->
+    <section id="storyline" class="timeline-section" aria-labelledby="storyline-title">
+      <div class="section-header">
+        <h2 id="storyline-title">Storyline</h2>
+        <p>A short arc of milestones linking family, scholarship, and actuarial analytics.</p>
+      </div>
+      <div class="timeline-shell">
+        <button class="timeline-control" type="button" data-direction="prev" aria-label="Scroll timeline backward">
+          <span aria-hidden="true">&#8592;</span>
+        </button>
+        <div class="timeline-track" role="list" aria-label="Luis Rodriguez timeline">
+          <article class="timeline-card" role="listitem" tabindex="0">
+            <p class="timeline-date">Dec 2007</p>
+            <h3>New roots in Nebraska</h3>
+            <p>Immigrated from Cuba with family, learning English and gravitating toward the certainty of mathematics.</p>
+          </article>
+          <article class="timeline-card" role="listitem" tabindex="0">
+            <p class="timeline-date">Aug 2018 – May 2019</p>
+            <h3>Student voice takes the mic</h3>
+            <p>Served as Grand Island Public Schools student board representative for 4,000+ classmates while meeting fellow math-enthusiast Madi in Oct 2018.</p>
+          </article>
+          <article class="timeline-card" role="listitem" tabindex="0">
+            <p class="timeline-date">Jan 2019</p>
+            <h3>Statewide spotlight</h3>
+            <p>Addressed Nebraska Association of School Boards leaders about student priorities at the annual meeting.</p>
+          </article>
+          <article class="timeline-card" role="listitem" tabindex="0">
+            <p class="timeline-date">Aug 2019</p>
+            <h3>Dual-degree kickoff</h3>
+            <p>Started concurrent Economics (Data Analytics) and Mathematics (Statistics &amp; Data Science) programs at UNO, aiming for dual 4.0 GPAs.</p>
+          </article>
+          <article class="timeline-card" role="listitem" tabindex="0">
+            <p class="timeline-date">Nov 2021 – Apr 2022</p>
+            <h3>Financial planning runway</h3>
+            <p>Joined Northwestern Mutual as a financial representative intern, translating analytics into client-ready plans.</p>
+          </article>
+          <article class="timeline-card" role="listitem" tabindex="0">
+            <p class="timeline-date">Mar 2022</p>
+            <h3>Finite-field breakthrough</h3>
+            <p>Presented numerical range research at UNO’s Student Research &amp; Creative Activity Fair, sharing abstract results with applied audiences.</p>
+          </article>
+          <article class="timeline-card" role="listitem" tabindex="0">
+            <p class="timeline-date">Apr 2022 – Feb 2024</p>
+            <h3>Wealth modeling craft</h3>
+            <p>Built valuation and PX planning models at Ludacka Wealth Partners, supporting clients with complex portfolios.</p>
+          </article>
+          <article class="timeline-card" role="listitem" tabindex="0">
+            <p class="timeline-date">May 2023</p>
+            <h3>Milestone May</h3>
+            <p>Graduated summa cum laude with dual 4.0 GPAs and married high-school sweetheart Madi.</p>
+          </article>
+          <article class="timeline-card" role="listitem" tabindex="0">
+            <p class="timeline-date">Jan 2024</p>
+            <h3>Family chapter</h3>
+            <p>Became a parent, balancing actuarial study sessions with newborn routines.</p>
+          </article>
+          <article class="timeline-card" role="listitem" tabindex="0">
+            <p class="timeline-date">Feb 2024</p>
+            <h3>Actuarial launch</h3>
+            <p>Joined Telos Actuarial to modernize reserving analytics using VBA automation, SQL modeling, and Excel reporting.</p>
+          </article>
+          <article class="timeline-card" role="listitem" tabindex="0">
+            <p class="timeline-date">Apr – Oct 2024</p>
+            <h3>Exam sprint</h3>
+            <p>Passed SOA exams FM, P, SRM, and PA in a single year while stepping into actuarial leadership at work and home.</p>
+          </article>
+          <article class="timeline-card" role="listitem" tabindex="0">
+            <p class="timeline-date">Sep 26, 2024</p>
+            <h3>Mission moment</h3>
+            <p>Shared the Rodriguez family story as the GIPS Harvest gala “Mission Moment” speaker alongside Madi.</p>
+          </article>
+          <article class="timeline-card" role="listitem" tabindex="0">
+            <p class="timeline-date">Dec 2024</p>
+            <h3>Fitness Toolkit</h3>
+            <p>Released a lightweight wellness toolkit that keeps workouts and recovery data visible for friends and colleagues.</p>
+          </article>
+          <article class="timeline-card" role="listitem" tabindex="0">
+            <p class="timeline-date">May – Jun 2025</p>
+            <h3>Secret side quest</h3>
+            <p>Collaborated on a confidential, challenge-based production lovingly dubbed the “Super Secret Special Project.”</p>
+          </article>
+        </div>
+        <button class="timeline-control" type="button" data-direction="next" aria-label="Scroll timeline forward">
+          <span aria-hidden="true">&#8594;</span>
+        </button>
+      </div>
+    </section>
+
+    <!-- Employment section -->
+    <section id="employment" class="content-section" aria-labelledby="employment-title">
+      <div class="section-header">
+        <h2 id="employment-title">Employment</h2>
+        <p>Roles spanning actuarial analytics, wealth planning, tutoring, and formative service work.</p>
+      </div>
+      <div class="card-grid">
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Actuarial Analyst · Telos Actuarial</span>
+              <span class="summary-meta">Feb 2024 – Present · Omaha, Nebraska</span>
+            </div>
+          </summary>
+          <ul>
+            <li>Automate reserving and reporting pipelines with Azure connectors, Microsoft Access, and SQL before packaging deliverables inside VBA-enhanced Excel dashboards.</li>
+            <li>Build projection models for rate increase filings that blend actuarial technique with disciplined data engineering to keep forecasts timely and defensible.</li>
+            <li>Design lightweight self-service scenario tools in Excel and VBA so teammates can pressure-test assumptions without manual rework.</li>
+          </ul>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Financial Planning Analyst · Ludacka Wealth Partners</span>
+              <span class="summary-meta">Apr 2022 – Feb 2024 · Omaha, Nebraska</span>
+            </div>
+          </summary>
+          <ul>
+            <li>Partnered with the Chief Investment Officer to build valuation models for Signature Choice portfolios, aligning analytics with each client’s risk tolerance.</li>
+            <li>Developed personalized financial plans for ultra-high-net-worth clients and Northwestern Mutual executives, translating complex strategies into clear decisions.</li>
+            <li>Oversaw the PX model library, ensured underwriting packages met jumbo-case requirements over $50K premiums, and maintained Series 7/63 readiness.</li>
+          </ul>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Financial Representative Intern · Northwestern Mutual</span>
+              <span class="summary-meta">Nov 2021 – Apr 2022 · Omaha, Nebraska</span>
+            </div>
+          </summary>
+          <ul>
+            <li>Strengthened networking, relationship management, and outreach to support client-centered planning conversations.</li>
+            <li>Assisted with financial plans and insurance proposals, aligning analytical insights with approachable product recommendations.</li>
+            <li>Expanded knowledge of insurance and risk management while sharpening communication through structured sales training.</li>
+          </ul>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Mathematics Tutor · UNO College of Business Administration</span>
+              <span class="summary-meta">Aug 2020 – Dec 2021 · Omaha, Nebraska</span>
+            </div>
+          </summary>
+          <ul>
+            <li>Delivered 3,000+ minutes of individualized tutoring each semester, supporting calculus and analytics coursework.</li>
+            <li>Managed a scheduling platform and customized study roadmaps that reduced student anxiety around quantitative topics.</li>
+          </ul>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Cashier · Runza Restaurants</span>
+              <span class="summary-meta">Sep 2017 – Aug 2019 · Grand Island, Nebraska</span>
+            </div>
+          </summary>
+          <ul>
+            <li>Handled fast-paced point-of-sale responsibilities while coaching new teammates on service and hospitality basics.</li>
+          </ul>
+        </details>
+      </div>
+    </section>
+
+    <!-- Education section -->
+    <section id="education" class="content-section" aria-labelledby="education-title">
+      <div class="section-header">
+        <h2 id="education-title">Education</h2>
+        <p>Dual-degree foundation bridging economics, statistics, and data science.</p>
+      </div>
+      <div class="card-grid">
+        <details open>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">University of Nebraska–Omaha · B.A. Economics &amp; B.S. Mathematics</span>
+              <span class="summary-meta">Aug 2019 – May 2023 · Omaha, Nebraska</span>
+            </div>
+          </summary>
+          <ul>
+            <li>Graduated summa cum laude with 4.0 GPAs in both majors; Economics concentration in Data Analytics and Mathematics focus in Statistics &amp; Data Science.</li>
+            <li>Earned Undergraduate Major Distinctions while maintaining Chancellor’s and Dean’s List honors every semester.</li>
+          </ul>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Grand Island Senior High School · High School Diploma</span>
+              <span class="summary-meta">2015 – 2019 · Grand Island, Nebraska</span>
+            </div>
+          </summary>
+          <ul>
+            <li>Served as the student representative to the Grand Island Public Schools Board of Education.</li>
+            <li>Secured scholarships that opened a debt-free path into UNO’s dual-degree experience.</li>
+          </ul>
+        </details>
+      </div>
+    </section>
+
+    <!-- Research section -->
+    <section id="research" class="content-section" aria-labelledby="research-title">
+      <div class="section-header">
+        <h2 id="research-title">Research</h2>
+        <p>Projects applying mathematical rigor to practical decision-making.</p>
+      </div>
+      <div class="card-grid">
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Linear Algebra over Finite Fields · Research Paper</span>
+              <span class="summary-meta">Fall 2021 – Spring 2022 · University of Nebraska–Omaha</span>
+            </div>
+          </summary>
+          <ul>
+            <li>Explored numerical ranges over finite fields in higher dimensions, focusing on patterns in <em>ℤ<sub>p</sub>[i]</em> where primes are congruent to 3 mod 4.</li>
+            <li>Strengthened advanced linear algebra and abstract mathematics skills while translating findings for broader audiences.</li>
+          </ul>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Optimizing Wedding Venue Selection · Published Honors Thesis</span>
+              <span class="summary-meta">Spring 2023 · UNO Honors Symposium</span>
+            </div>
+          </summary>
+          <ul>
+            <li>Developed an IBM ILOG CPLEX integer programming model to balance guest counts, budgets, and logistics for venue selection.</li>
+            <li>Demonstrated how operations research can inform personal and organizational decisions with measurable impact.</li>
+          </ul>
+        </details>
+      </div>
+    </section>
+
+    <!-- Presentations section -->
+    <section id="presentations" class="content-section" aria-labelledby="presentations-title">
+      <div class="section-header">
+        <h2 id="presentations-title">Presentations</h2>
+        <p>Talks translating mathematical insight for academic and community audiences.</p>
+      </div>
+      <div class="card-grid">
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">UNO Creative Activity Fair · University of Nebraska–Omaha</span>
+              <span class="summary-meta">2022 · Omaha, Nebraska</span>
+            </div>
+          </summary>
+          <p>Presented finite-field research, sharing patterns in complex numerical ranges with interdisciplinary peers.</p>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Nebraska–SE South Dakota MAA Conference · Mathematical Association of America</span>
+              <span class="summary-meta">2022 · Nebraska</span>
+            </div>
+          </summary>
+          <p>Delivered a talk on higher-dimensional numerical ranges, emphasizing communication of advanced mathematics to broad audiences.</p>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">UNO Honors Symposium · University of Nebraska–Omaha</span>
+              <span class="summary-meta">2023 · Omaha, Nebraska</span>
+            </div>
+          </summary>
+          <p>Presented the wedding venue optimization thesis, highlighting real-world applications of integer programming.</p>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">NASB Annual Meeting · Nebraska Association of School Boards</span>
+              <span class="summary-meta">Jan 2019 · Nebraska</span>
+            </div>
+            <span class="summary-actions">
+              <span class="info-wrapper">
+                <button type="button" class="info-trigger" aria-label="More about the NASB talk" aria-expanded="false" data-tooltip-target="tooltip-nasb">
+                  <span aria-hidden="true">i</span>
+                </button>
+                <span class="tooltip" id="tooltip-nasb" role="tooltip" hidden>
+                  Selected to represent Grand Island students before state education leaders, sharing priorities shaped by board service.
+                </span>
+              </span>
+            </span>
+          </summary>
+          <p>Shared student priorities with education decision makers across Nebraska.</p>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">GIPS Harvest “Mission Moment” · Grand Island Public Schools Foundation</span>
+              <span class="summary-meta">Sep 26, 2024 · Grand Island, Nebraska</span>
+            </div>
+          </summary>
+          <p>Spoke alongside Madi about scholarships, family, and community impact during the foundation’s signature event.</p>
+        </details>
+      </div>
+    </section>
+
+    <!-- Skills section -->
+    <section id="skills" class="content-section" aria-labelledby="skills-title">
+      <div class="section-header">
+        <h2 id="skills-title">Skills</h2>
+        <p>Technical stack spanning analytics platforms, programming, documentation, and languages.</p>
+      </div>
+      <div class="card-grid">
+        <details open>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Dashboard &amp; Visualization</span>
+            </div>
+          </summary>
+          <p>Tableau, Power BI.</p>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Programming &amp; Data Tools</span>
+            </div>
+          </summary>
+          <p>SQL, Python, R, Regular Expressions, Java, JavaScript.</p>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Markup &amp; Documentation</span>
+            </div>
+          </summary>
+          <p>HTML, LaTeX, R Markdown.</p>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Microsoft Office Suite</span>
+            </div>
+          </summary>
+          <p>Access, Excel, Outlook, OneNote, PowerPoint, Word.</p>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Languages</span>
+            </div>
+          </summary>
+          <p>English, Spanish.</p>
+        </details>
+      </div>
+    </section>
+
+    <!-- Leadership section -->
+    <section id="leadership" class="content-section" aria-labelledby="leadership-title">
+      <div class="section-header">
+        <h2 id="leadership-title">Leadership</h2>
+        <p>Service and governance roles across campus and community.</p>
+      </div>
+      <div class="card-grid">
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">UNO Honors Student Association · Treasurer</span>
+              <span class="summary-meta">May 2020 – May 2021 · Omaha, Nebraska</span>
+            </div>
+          </summary>
+          <p>Managed finances, fundraising, and reimbursements for honors programming.</p>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">UNO Economics Club · Treasurer &amp; President</span>
+              <span class="summary-meta">Jan 2020 – May 2023 · Omaha, Nebraska</span>
+            </div>
+          </summary>
+          <ul>
+            <li>Coordinated budgeting as Treasurer (Jan 2020 – Aug 2021).</li>
+            <li>Directed programming and partnerships as President (Aug 2021 – May 2023).</li>
+          </ul>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">UNO Financial Management Association · Vice President</span>
+              <span class="summary-meta">Sep 2021 – Jan 2022 · Omaha, Nebraska</span>
+            </div>
+          </summary>
+          <p>Collaborated with officers to plan events and coordinate member engagement.</p>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Grand Island Public Schools District · Student Board Representative</span>
+              <span class="summary-meta">Aug 2018 – May 2019 · Grand Island, Nebraska</span>
+            </div>
+            <span class="summary-actions">
+              <span class="info-wrapper">
+                <button type="button" class="info-trigger" aria-label="More about the student board role" aria-expanded="false" data-tooltip-target="tooltip-gips">
+                  <span aria-hidden="true">i</span>
+                </button>
+                <span class="tooltip" id="tooltip-gips" role="tooltip" hidden>
+                  Represented the voices of over 4,000 students, advising administrators on policy and opportunity design.
+                </span>
+              </span>
+            </span>
+          </summary>
+          <p>Delivered student perspectives to district leadership while building public speaking confidence.</p>
+        </details>
+      </div>
+    </section>
+
+    <!-- Awards and honors section -->
+    <section id="awards" class="content-section" aria-labelledby="awards-title">
+      <div class="section-header">
+        <h2 id="awards-title">Awards &amp; Honors</h2>
+        <p>Recognition for scholarship, leadership, and sustained academic excellence.</p>
+      </div>
+      <div class="card-grid">
+        <details open>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Honor Societies</span>
+            </div>
+          </summary>
+          <ul>
+            <li>
+              <span>Phi Kappa Phi · 2020</span>
+              <span class="info-wrapper">
+                <button type="button" class="info-trigger" aria-label="More about Phi Kappa Phi" aria-expanded="false" data-tooltip-target="tooltip-phi">
+                  <span aria-hidden="true">i</span>
+                </button>
+                <span class="tooltip" id="tooltip-phi" role="tooltip" hidden>
+                  Invitation-only honor society recognizing the top 7.5% of students across all disciplines.
+                </span>
+              </span>
+            </li>
+            <li>Pi Mu Epsilon · 2021</li>
+            <li>Omicron Delta Epsilon · 2020</li>
+          </ul>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Scholarships</span>
+            </div>
+          </summary>
+          <ul>
+            <li>
+              <span>Susan Thompson Buffett Scholarship · 2019</span>
+              <span class="info-wrapper">
+                <button type="button" class="info-trigger" aria-label="More about the Buffett Scholarship" aria-expanded="false" data-tooltip-target="tooltip-buffett">
+                  <span aria-hidden="true">i</span>
+                </button>
+                <span class="tooltip" id="tooltip-buffett" role="tooltip" hidden>
+                  Competitive statewide award supporting Nebraska students with demonstrated academic excellence and need.
+                </span>
+              </span>
+            </li>
+            <li>
+              <span>Jack and Lucile Martin Scholarship · 2019</span>
+              <span class="info-wrapper">
+                <button type="button" class="info-trigger" aria-label="More about the Martin Scholarship" aria-expanded="false" data-tooltip-target="tooltip-martin">
+                  <span aria-hidden="true">i</span>
+                </button>
+                <span class="tooltip" id="tooltip-martin" role="tooltip" hidden>
+                  Merit-based award that helped launch Luis and Madi’s UNO journey with financial stability.
+                </span>
+              </span>
+            </li>
+          </ul>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Academic Honors</span>
+            </div>
+          </summary>
+          <ul>
+            <li>Chancellor’s List · Eight semesters (2019 – 2023)</li>
+            <li>Dean’s List · Eight semesters (2019 – 2023)</li>
+          </ul>
+        </details>
+      </div>
+    </section>
+
+    <!-- Certifications section -->
+    <section id="certifications" class="content-section" aria-labelledby="certifications-title">
+      <div class="section-header">
+        <h2 id="certifications-title">Certifications</h2>
+        <p>Licenses and examinations affirming actuarial and financial readiness.</p>
+      </div>
+      <div class="card-grid">
+        <details open>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Society of Actuaries · Preliminary Exams</span>
+              <span class="summary-meta">2024</span>
+            </div>
+            <span class="summary-actions">
+              <span class="info-wrapper">
+                <button type="button" class="info-trigger" aria-label="More about the SOA exam streak" aria-expanded="false" data-tooltip-target="tooltip-exams">
+                  <span aria-hidden="true">i</span>
+                </button>
+                <span class="tooltip" id="tooltip-exams" role="tooltip" hidden>
+                  Cleared four SOA preliminary exams in 2024 while transitioning into Telos Actuarial and new parenthood.
+                </span>
+              </span>
+            </span>
+          </summary>
+          <ul>
+            <li>Exam FM: Financial Mathematics · Apr 2024</li>
+            <li>Exam P: Probability · Jul 2024</li>
+            <li>Exam SRM: Statistics for Risk Modeling · Sep 2024</li>
+            <li>Exam PA: Predictive Analytics · Oct 2024</li>
+          </ul>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">FINRA Licenses</span>
+            </div>
+          </summary>
+          <ul>
+            <li>Series 63: Uniform Securities Agent State Law Exam · 2023</li>
+            <li>Series 7: General Securities Representative Exam · 2023</li>
+          </ul>
+        </details>
+        <details>
+          <summary>
+            <div class="summary-content">
+              <span class="summary-title">Insurance &amp; Research Credentials</span>
+            </div>
+          </summary>
+          <ul>
+            <li>NAIC Insurance Producer: Life, Annuities, &amp; Health · NPN ID 20190700 · 2021</li>
+            <li>CITI Program: Group 3 Social &amp; Behavioral Research · Credential ID 46348703 · 2021</li>
+          </ul>
+        </details>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>© 2025 Luis Rodriguez. Built for quick review on any device.</p>
+  </footer>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,245 @@
+// Entry point: prepare interactive timeline and info tooltips once the DOM is ready.
+document.addEventListener('DOMContentLoaded', () => {
+  initTimeline();
+  initTooltips();
+});
+
+/**
+ * Initialize the horizontal timeline with keyboard support, scroll snapping,
+ * and previous/next controls. The component remains swipeable for touch users
+ * while preserving accessibility for keyboard navigation.
+ */
+function initTimeline() {
+  const track = document.querySelector('.timeline-track');
+  if (!track) return;
+
+  const cards = Array.from(track.querySelectorAll('.timeline-card'));
+  const controls = Array.from(document.querySelectorAll('.timeline-control'));
+  if (!cards.length) return;
+
+  let activeIndex = 0;
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  const clampIndex = (value) => Math.max(0, Math.min(value, cards.length - 1));
+
+  const updateAria = () => {
+    cards.forEach((card, idx) => {
+      if (idx === activeIndex) {
+        card.setAttribute('aria-current', 'true');
+        card.classList.add('is-active');
+      } else {
+        card.setAttribute('aria-current', 'false');
+        card.classList.remove('is-active');
+      }
+    });
+
+    controls.forEach((control) => {
+      const direction = control.dataset.direction;
+      if (direction === 'prev') {
+        control.disabled = activeIndex === 0;
+      } else if (direction === 'next') {
+        control.disabled = activeIndex === cards.length - 1;
+      }
+    });
+  };
+
+  const scrollToIndex = (index) => {
+    activeIndex = clampIndex(index);
+    const targetCard = cards[activeIndex];
+    if (!targetCard) return;
+
+    const behavior = reduceMotion.matches ? 'auto' : 'smooth';
+    targetCard.scrollIntoView({ behavior, block: 'nearest', inline: 'center' });
+    if (typeof targetCard.focus === 'function') {
+      targetCard.focus({ preventScroll: true });
+    }
+    updateAria();
+  };
+
+  controls.forEach((control) => {
+    control.addEventListener('click', () => {
+      const delta = control.dataset.direction === 'next' ? 1 : -1;
+      scrollToIndex(activeIndex + delta);
+    });
+  });
+
+  cards.forEach((card, idx) => {
+    card.addEventListener('focus', () => {
+      activeIndex = idx;
+      updateAria();
+    });
+
+    card.addEventListener('keydown', (event) => {
+      if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        scrollToIndex(idx + 1);
+      } else if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        scrollToIndex(idx - 1);
+      } else if (event.key === 'Home') {
+        event.preventDefault();
+        scrollToIndex(0);
+      } else if (event.key === 'End') {
+        event.preventDefault();
+        scrollToIndex(cards.length - 1);
+      }
+    });
+  });
+
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting && entry.intersectionRatio >= 0.55) {
+            const index = cards.indexOf(entry.target);
+            if (index !== -1) {
+              activeIndex = index;
+              updateAria();
+            }
+          }
+        });
+      },
+      { root: track, threshold: 0.55 }
+    );
+
+    cards.forEach((card) => observer.observe(card));
+  }
+
+  updateAria();
+}
+
+/**
+ * Initialize tooltip toggles for contextual info icons. Tooltips are positioned
+ * dynamically to remain inside the viewport, close on blur or Escape, and are
+ * safe for touch interactions.
+ */
+function initTooltips() {
+  const triggers = Array.from(document.querySelectorAll('.info-trigger'));
+  if (!triggers.length) return;
+
+  let openButton = null;
+
+  const getTooltip = (button) => {
+    const id = button.getAttribute('data-tooltip-target');
+    return id ? document.getElementById(id) : null;
+  };
+
+  const closeTooltip = (button) => {
+    if (!button) return;
+    const tooltip = getTooltip(button);
+    if (!tooltip) return;
+
+    tooltip.hidden = true;
+    tooltip.removeAttribute('data-visible');
+    tooltip.removeAttribute('data-position');
+    button.setAttribute('aria-expanded', 'false');
+    button.removeAttribute('aria-describedby');
+    if (openButton === button) {
+      openButton = null;
+    }
+  };
+
+  const positionTooltip = (button, tooltip) => {
+    const padding = 12;
+    const rect = button.getBoundingClientRect();
+    const tipRect = tooltip.getBoundingClientRect();
+    let top = rect.bottom + 10;
+    let position = 'bottom';
+
+    if (top + tipRect.height + padding > window.innerHeight) {
+      top = rect.top - tipRect.height - 10;
+      position = 'top';
+    }
+
+    let left = rect.left + rect.width / 2 - tipRect.width / 2;
+    if (left < padding) {
+      left = padding;
+    }
+    if (left + tipRect.width + padding > window.innerWidth) {
+      left = window.innerWidth - tipRect.width - padding;
+    }
+
+    tooltip.style.left = `${Math.round(left)}px`;
+    tooltip.style.top = `${Math.round(Math.max(top, padding))}px`;
+    tooltip.setAttribute('data-position', position);
+  };
+
+  const openTooltip = (button) => {
+    const tooltip = getTooltip(button);
+    if (!tooltip) return;
+
+    if (openButton && openButton !== button) {
+      closeTooltip(openButton);
+    }
+
+    tooltip.hidden = false;
+    tooltip.setAttribute('data-visible', 'true');
+    button.setAttribute('aria-expanded', 'true');
+    button.setAttribute('aria-describedby', tooltip.id);
+    openButton = button;
+
+    // Position on the next frame to ensure measurements use the visible tooltip.
+    requestAnimationFrame(() => {
+      positionTooltip(button, tooltip);
+    });
+  };
+
+  const toggleTooltip = (event) => {
+    event.stopPropagation();
+    const button = event.currentTarget;
+    const tooltip = getTooltip(button);
+    if (!tooltip) return;
+
+    const willOpen = tooltip.hidden;
+    if (willOpen) {
+      openTooltip(button);
+    } else {
+      closeTooltip(button);
+    }
+  };
+
+  triggers.forEach((button) => {
+    button.addEventListener('click', toggleTooltip);
+    button.addEventListener('pointerdown', (event) => event.stopPropagation());
+    button.addEventListener('keydown', (event) => event.stopPropagation());
+    button.addEventListener('blur', () => {
+      setTimeout(() => {
+        if (document.activeElement !== button) {
+          closeTooltip(button);
+        }
+      }, 80);
+    });
+  });
+
+  document.addEventListener(
+    'pointerdown',
+    (event) => {
+      if (!openButton) return;
+      const tooltip = getTooltip(openButton);
+      if (!tooltip) return;
+      const isButton = openButton.contains(event.target);
+      const isTooltip = tooltip.contains(event.target);
+      if (!isButton && !isTooltip) {
+        closeTooltip(openButton);
+      }
+    },
+    true
+  );
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && openButton) {
+      closeTooltip(openButton);
+      openButton.focus({ preventScroll: true });
+    }
+  });
+
+  const repositionOpenTooltip = () => {
+    if (!openButton) return;
+    const tooltip = getTooltip(openButton);
+    if (!tooltip || tooltip.hidden) return;
+    positionTooltip(openButton, tooltip);
+  };
+
+  window.addEventListener('resize', repositionOpenTooltip);
+  document.addEventListener('scroll', repositionOpenTooltip, true);
+}

--- a/styles.css
+++ b/styles.css
@@ -1,1 +1,472 @@
-*,:after,:before{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgba(59,130,246,.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: ;--tw-contain-size: ;--tw-contain-layout: ;--tw-contain-paint: ;--tw-contain-style: }::backdrop{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgba(59,130,246,.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: ;--tw-contain-size: ;--tw-contain-layout: ;--tw-contain-paint: ;--tw-contain-style: }/*! tailwindcss v3.4.17 | MIT License | https://tailwindcss.com*/*,:after,:before{box-sizing:border-box;border:0 solid #e5e7eb}:after,:before{--tw-content:""}:host,html{line-height:1.5;-webkit-text-size-adjust:100%;-moz-tab-size:4;-o-tab-size:4;tab-size:4;font-family:Inter,sans-serif;font-feature-settings:normal;font-variation-settings:normal;-webkit-tap-highlight-color:transparent}body{margin:0;line-height:inherit}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){-webkit-text-decoration:underline dotted;text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,pre,samp{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;font-feature-settings:normal;font-variation-settings:normal;font-size:1em}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}button,input,optgroup,select,textarea{font-family:inherit;font-feature-settings:inherit;font-variation-settings:inherit;font-size:100%;font-weight:inherit;line-height:inherit;letter-spacing:inherit;color:inherit;margin:0;padding:0}button,select{text-transform:none}button,input:where([type=button]),input:where([type=reset]),input:where([type=submit]){-webkit-appearance:button;background-color:transparent;background-image:none}:-moz-focusring{outline:auto}:-moz-ui-invalid{box-shadow:none}progress{vertical-align:baseline}::-webkit-inner-spin-button,::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}summary{display:list-item}blockquote,dd,dl,figure,h1,h2,h3,h4,h5,h6,hr,p,pre{margin:0}fieldset{margin:0}fieldset,legend{padding:0}menu,ol,ul{list-style:none;margin:0;padding:0}dialog{padding:0}textarea{resize:vertical}input::-moz-placeholder,textarea::-moz-placeholder{opacity:1;color:#9ca3af}input::placeholder,textarea::placeholder{opacity:1;color:#9ca3af}[role=button],button{cursor:pointer}:disabled{cursor:default}audio,canvas,embed,iframe,img,object,svg,video{display:block;vertical-align:middle}img,video{max-width:100%;height:auto}[hidden]:where(:not([hidden=until-found])){display:none}.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}.pointer-events-none{pointer-events:none}.visible{visibility:visible}.absolute{position:absolute}.relative{position:relative}.sticky{position:sticky}.left-0{left:0}.left-1\/2{left:50%}.right-0{right:0}.right-4{right:1rem}.top-0{top:0}.top-1\/2{top:50%}.z-50{z-index:50}.m-2{margin:.5rem}.mx-auto{margin-left:auto;margin-right:auto}.my-6{margin-top:1.5rem;margin-bottom:1.5rem}.mb-2{margin-bottom:.5rem}.mb-4{margin-bottom:1rem}.mb-6{margin-bottom:1.5rem}.ml-1{margin-left:.25rem}.ml-2{margin-left:.5rem}.mr-2{margin-right:.5rem}.mr-4{margin-right:1rem}.mt-1{margin-top:.25rem}.mt-2{margin-top:.5rem}.inline-block{display:inline-block}.inline{display:inline}.flex{display:flex}.grid{display:grid}.hidden{display:none}.h-12{height:3rem}.h-3{height:.75rem}.h-4{height:1rem}.h-6{height:1.5rem}.min-h-screen{min-height:100vh}.w-12{width:3rem}.w-3{width:.75rem}.w-4{width:1rem}.w-6{width:1.5rem}.w-72{width:18rem}.w-full{width:100%}.max-w-2xl{max-width:42rem}.max-w-3xl{max-width:48rem}.max-w-md{max-width:28rem}.flex-shrink-0,.shrink-0{flex-shrink:0}.-translate-x-1\/2{--tw-translate-x:-50%}.-translate-x-1\/2,.-translate-y-1\/2{transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.-translate-y-1\/2{--tw-translate-y:-50%}.translate-y-0{--tw-translate-y:0px}.translate-y-0,.translate-y-4{transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.translate-y-4{--tw-translate-y:1rem}.transform{transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.select-none{-webkit-user-select:none;-moz-user-select:none;user-select:none}.snap-x{scroll-snap-type:x var(--tw-scroll-snap-strictness)}.snap-mandatory{--tw-scroll-snap-strictness:mandatory}.snap-start{scroll-snap-align:start}.list-inside{list-style-position:inside}.list-disc{list-style-type:disc}.grid-cols-1{grid-template-columns:repeat(1,minmax(0,1fr))}.flex-col{flex-direction:column}.items-start{align-items:flex-start}.items-center{align-items:center}.justify-center{justify-content:center}.gap-4{gap:1rem}.space-x-4>:not([hidden])~:not([hidden]){--tw-space-x-reverse:0;margin-right:calc(1rem*var(--tw-space-x-reverse));margin-left:calc(1rem*(1 - var(--tw-space-x-reverse)))}.space-y-1>:not([hidden])~:not([hidden]){--tw-space-y-reverse:0;margin-top:calc(.25rem*(1 - var(--tw-space-y-reverse)));margin-bottom:calc(.25rem*var(--tw-space-y-reverse))}.space-y-2>:not([hidden])~:not([hidden]){--tw-space-y-reverse:0;margin-top:calc(.5rem*(1 - var(--tw-space-y-reverse)));margin-bottom:calc(.5rem*var(--tw-space-y-reverse))}.space-y-3>:not([hidden])~:not([hidden]){--tw-space-y-reverse:0;margin-top:calc(.75rem*(1 - var(--tw-space-y-reverse)));margin-bottom:calc(.75rem*var(--tw-space-y-reverse))}.space-y-6>:not([hidden])~:not([hidden]){--tw-space-y-reverse:0;margin-top:calc(1.5rem*(1 - var(--tw-space-y-reverse)));margin-bottom:calc(1.5rem*var(--tw-space-y-reverse))}.overflow-x-auto{overflow-x:auto}.whitespace-nowrap{white-space:nowrap}.rounded{border-radius:.25rem}.rounded-2xl{border-radius:1rem}.rounded-full{border-radius:9999px}.border{border-width:1px}.border-l-2{border-left-width:2px}.border-primary{--tw-border-opacity:1;border-color:rgb(13 148 136/var(--tw-border-opacity,1))}.bg-background{--tw-bg-opacity:1;background-color:rgb(247 248 250/var(--tw-bg-opacity,1))}.bg-gray-800{--tw-bg-opacity:1;background-color:rgb(31 41 55/var(--tw-bg-opacity,1))}.bg-primary{--tw-bg-opacity:1;background-color:rgb(13 148 136/var(--tw-bg-opacity,1))}.bg-white{--tw-bg-opacity:1;background-color:rgb(255 255 255/var(--tw-bg-opacity,1))}.object-cover{-o-object-fit:cover;object-fit:cover}.p-2{padding:.5rem}.p-4{padding:1rem}.p-6{padding:1.5rem}.px-2{padding-left:.5rem;padding-right:.5rem}.px-4{padding-left:1rem;padding-right:1rem}.px-6{padding-left:1.5rem;padding-right:1.5rem}.py-1{padding-top:.25rem;padding-bottom:.25rem}.py-2{padding-top:.5rem;padding-bottom:.5rem}.py-3{padding-top:.75rem;padding-bottom:.75rem}.py-6{padding-top:1.5rem;padding-bottom:1.5rem}.pb-4{padding-bottom:1rem}.pl-4{padding-left:1rem}.text-left{text-align:left}.text-center{text-align:center}.text-2xl{font-size:1.5rem;line-height:2rem}.text-3xl{font-size:1.875rem;line-height:2.25rem}.text-base{font-size:1rem;line-height:1.5rem}.text-sm{font-size:.875rem;line-height:1.25rem}.text-xl{font-size:1.25rem;line-height:1.75rem}.text-xs{font-size:.75rem;line-height:1rem}.font-bold{font-weight:700}.font-medium{font-weight:500}.font-semibold{font-weight:600}.leading-relaxed{line-height:1.625}.text-\[\#0033a0\]{--tw-text-opacity:1;color:rgb(0 51 160/var(--tw-text-opacity,1))}.text-\[\#0d9488\]{--tw-text-opacity:1;color:rgb(13 148 136/var(--tw-text-opacity,1))}.text-gray-500{--tw-text-opacity:1;color:rgb(107 114 128/var(--tw-text-opacity,1))}.text-gray-600{--tw-text-opacity:1;color:rgb(75 85 99/var(--tw-text-opacity,1))}.text-gray-700{--tw-text-opacity:1;color:rgb(55 65 81/var(--tw-text-opacity,1))}.text-green-600{--tw-text-opacity:1;color:rgb(22 163 74/var(--tw-text-opacity,1))}.text-primary{--tw-text-opacity:1;color:rgb(13 148 136/var(--tw-text-opacity,1))}.text-purple-600{--tw-text-opacity:1;color:rgb(147 51 234/var(--tw-text-opacity,1))}.text-red-500{--tw-text-opacity:1;color:rgb(239 68 68/var(--tw-text-opacity,1))}.text-red-600{--tw-text-opacity:1;color:rgb(220 38 38/var(--tw-text-opacity,1))}.text-text{--tw-text-opacity:1;color:rgb(31 41 55/var(--tw-text-opacity,1))}.text-white{--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity,1))}.underline{text-decoration-line:underline}.decoration-primary{text-decoration-color:#0d9488}.underline-offset-2{text-underline-offset:2px}.opacity-0{opacity:0}.opacity-100{opacity:1}.shadow{--tw-shadow:0 1px 3px 0 rgba(0,0,0,.1),0 1px 2px -1px rgba(0,0,0,.1);--tw-shadow-colored:0 1px 3px 0 var(--tw-shadow-color),0 1px 2px -1px var(--tw-shadow-color)}.shadow,.shadow-md{box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}.shadow-md{--tw-shadow:0 4px 6px -1px rgba(0,0,0,.1),0 2px 4px -2px rgba(0,0,0,.1);--tw-shadow-colored:0 4px 6px -1px var(--tw-shadow-color),0 2px 4px -2px var(--tw-shadow-color)}.transition-opacity{transition-property:opacity;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.transition-shadow{transition-property:box-shadow;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.transition-transform{transition-property:transform;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.duration-700{transition-duration:.7s}.ease-out{transition-timing-function:cubic-bezier(0,0,.2,1)}html{scroll-behavior:smooth}body{background:linear-gradient(180deg,#f7f8fa,#fff)}a{text-decoration:underline;text-underline-offset:2px}.hover\:decoration-2:hover,a:hover{text-decoration-thickness:2px}.hover\:shadow-lg:hover{--tw-shadow:0 10px 15px -3px rgba(0,0,0,.1),0 4px 6px -4px rgba(0,0,0,.1);--tw-shadow-colored:0 10px 15px -3px var(--tw-shadow-color),0 4px 6px -4px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}.focus\:outline-none:focus{outline:2px solid transparent;outline-offset:2px}.focus\:ring-2:focus{--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow,0 0 #0000)}.focus\:ring-primary:focus{--tw-ring-opacity:1;--tw-ring-color:rgb(13 148 136/var(--tw-ring-opacity,1))}@media (min-width:640px){.sm\:flex{display:flex}.sm\:hidden{display:none}.sm\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.sm\:flex-row{flex-direction:row}.sm\:flex-wrap{flex-wrap:wrap}.sm\:space-x-4>:not([hidden])~:not([hidden]){--tw-space-x-reverse:0;margin-right:calc(1rem*var(--tw-space-x-reverse));margin-left:calc(1rem*(1 - var(--tw-space-x-reverse)))}.sm\:space-y-0>:not([hidden])~:not([hidden]){--tw-space-y-reverse:0;margin-top:calc(0px*(1 - var(--tw-space-y-reverse)));margin-bottom:calc(0px*var(--tw-space-y-reverse))}.sm\:px-6{padding-left:1.5rem;padding-right:1.5rem}}@media (min-width:768px){.md\:grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}}@media (min-width:1024px){.lg\:px-8{padding-left:2rem;padding-right:2rem}}
+:root {
+  color-scheme: light;
+  --bg: #f5f7fb;
+  --surface: #ffffff;
+  --surface-alt: #f0f4ff;
+  --border: #d7dff2;
+  --text: #13223a;
+  --text-muted: #536079;
+  --accent: #3154ff;
+  --accent-muted: #e4e9ff;
+  --shadow: 0 18px 42px rgba(19, 34, 58, 0.12);
+  --radius-large: 22px;
+  --radius-medium: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.skip-link {
+  position: absolute;
+  top: 0.75rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--accent);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  z-index: 100;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.skip-link:focus {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.site-header {
+  background: linear-gradient(135deg, rgba(49, 84, 255, 0.1), rgba(49, 84, 255, 0.05));
+  padding: clamp(1.5rem, 3vw + 1rem, 3.5rem) 1.25rem;
+}
+
+.summary-shell {
+  max-width: 1140px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1.75rem;
+}
+
+.summary-text .label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.summary-text h1 {
+  font-size: clamp(2.2rem, 3vw + 1.5rem, 3rem);
+  margin: 0;
+  line-height: 1.1;
+}
+
+.summary-text .role {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0.3rem 0;
+}
+
+.summary-text .location,
+.summary-text .contact {
+  margin: 0.2rem 0;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+.summary-text .intro {
+  margin-top: 0.9rem;
+  font-size: 1rem;
+  max-width: 56ch;
+}
+
+.summary-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.summary-nav a {
+  display: inline-block;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(49, 84, 255, 0.3);
+  background: rgba(255, 255, 255, 0.9);
+  font-size: 0.9rem;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.summary-nav a:hover,
+.summary-nav a:focus-visible {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+main {
+  max-width: 1140px;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.content-section,
+.timeline-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 1.7rem;
+  line-height: 1.2;
+}
+
+.section-header p {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.timeline-shell {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.75rem;
+  padding: 1.1rem 0.75rem;
+  border-radius: var(--radius-large);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  align-items: center;
+}
+
+.timeline-control {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  font-size: 1.3rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.timeline-control:disabled {
+  background: var(--accent-muted);
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+
+.timeline-control:hover:not(:disabled) {
+  transform: translateY(-2px);
+}
+
+.timeline-track {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(240px, 80vw);
+  gap: 1rem;
+  overflow-x: auto;
+  padding: 0.5rem;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-x;
+}
+
+.timeline-track::-webkit-scrollbar {
+  height: 6px;
+}
+
+.timeline-track::-webkit-scrollbar-thumb {
+  background: rgba(49, 84, 255, 0.3);
+  border-radius: 999px;
+}
+
+.timeline-track::before,
+.timeline-track::after {
+  content: "";
+  position: sticky;
+  top: 0;
+  width: 40px;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.timeline-track::before {
+  left: 0;
+  background: linear-gradient(90deg, var(--surface) 0%, rgba(255, 255, 255, 0));
+}
+
+.timeline-track::after {
+  right: 0;
+  background: linear-gradient(270deg, var(--surface) 0%, rgba(255, 255, 255, 0));
+}
+
+.timeline-card {
+  scroll-snap-align: center;
+  background: var(--surface-alt);
+  border-radius: var(--radius-medium);
+  border: 1px solid transparent;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  min-height: 200px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.timeline-card .timeline-date {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.timeline-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  line-height: 1.3;
+}
+
+.timeline-card p {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.timeline-card:is(:hover, :focus-visible, .is-active) {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 32px rgba(49, 84, 255, 0.18);
+  border-color: rgba(49, 84, 255, 0.4);
+  background: #fff;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.details-reset,
+details {
+  background: var(--surface);
+  border-radius: var(--radius-medium);
+  border: 1px solid var(--border);
+  padding: 1.1rem 1.25rem;
+  box-shadow: 0 12px 28px rgba(19, 34, 58, 0.08);
+}
+
+details + details {
+  margin-top: 0.25rem;
+}
+
+details[open] {
+  border-color: rgba(49, 84, 255, 0.4);
+}
+
+details summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+  font-size: 1rem;
+}
+
+details summary::-webkit-details-marker {
+  display: none;
+}
+
+.summary-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.summary-title {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.summary-meta {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+details[open] > *:not(summary) {
+  margin-top: 0.85rem;
+}
+
+details ul {
+  margin: 0;
+  padding-left: 1.15rem;
+  display: grid;
+  gap: 0.55rem;
+}
+
+details p {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.summary-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-left: auto;
+}
+
+.info-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.info-trigger {
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.info-trigger:hover,
+.info-trigger:focus-visible {
+  background: #1f3bdb;
+  color: #fff;
+}
+
+.tooltip {
+  position: fixed;
+  max-width: 260px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: 0 20px 44px rgba(19, 34, 58, 0.2);
+  padding: 0.75rem 0.9rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--text);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease;
+  z-index: 50;
+}
+
+.tooltip[data-visible="true"] {
+  opacity: 1;
+}
+
+.tooltip[data-position="top"]::after,
+.tooltip[data-position="bottom"]::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: inherit;
+  border-left: 1px solid var(--border);
+  border-top: 1px solid var(--border);
+  transform: rotate(45deg);
+  z-index: -1;
+}
+
+.tooltip[data-position="top"]::after {
+  bottom: -6px;
+  left: calc(50% - 6px);
+}
+
+.tooltip[data-position="bottom"]::after {
+  top: -6px;
+  left: calc(50% - 6px);
+}
+
+.site-footer {
+  padding: 2.5rem 1.25rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+/* Focus styles for keyboard navigation */
+:focus-visible {
+  outline: 3px solid rgba(49, 84, 255, 0.7);
+  outline-offset: 3px;
+}
+
+.timeline-control:focus-visible {
+  outline-offset: 4px;
+}
+
+/* Responsive layouts */
+@media (min-width: 768px) {
+  .summary-shell {
+    grid-template-columns: 1.9fr 1fr;
+    align-items: center;
+  }
+
+  .card-grid {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
+  .timeline-track {
+    grid-auto-columns: minmax(240px, 320px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild the root HTML to deliver a mobile-first personal site with summary banner, navigation, and storyline timeline for Luis Rodriguez
- restyle the experience with light-theme cards, responsive grids, and interactive resume sections powered by native `<details>` patterns and accessible info tooltips
- add vanilla JavaScript for swipeable timeline controls and viewport-aware tooltips that respect keyboard, touch, and reduced-motion preferences

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cae7eac9b083229df946362d7ebc99